### PR TITLE
add setting to run the game on startup

### DIFF
--- a/src/SettingsWindow.py
+++ b/src/SettingsWindow.py
@@ -35,6 +35,11 @@ class SettingsWindow(QMainWindow):
         self.sysTrayCheck.stateChanged.connect(self.toggleSysTray)
         self.main.layout.addWidget(self.sysTrayCheck)
 
+        self.runGameCheck = QCheckBox("Run Hunt on startup")
+        self.runGameCheck.setChecked(settings.value("run_game_on_startup","false").lower() == "true")
+        self.runGameCheck.stateChanged.connect(self.toggleRunGame)
+        self.main.layout.addWidget(self.runGameCheck)
+
         self.main.layout.addItem(QSpacerItem(0,16,QSizePolicy.Policy.Fixed,QSizePolicy.Policy.Fixed))
         self.initKdaRange()
         self.initDropdownRange()
@@ -74,6 +79,12 @@ class SettingsWindow(QMainWindow):
         else:
             w.showSysTray = False
             settings.setValue("show_sys_tray",False)
+
+    def toggleRunGame(self):
+        if self.runGameCheck.isChecked():
+            settings.setValue("run_game_on_startup",True)
+        else:
+            settings.setValue("run_game_on_startup",False)
 
     def initKdaRange(self):
         self.KdaRangeLabel = QLabel("Calculate KDA from the last...")
@@ -164,14 +175,17 @@ class SettingsWindow(QMainWindow):
             self.steamNameInput.setDisabled(False)
     
     def SelectFolderDialog(self):
-        suffix = "user/profiles/default/attributes.xml"
+        xml_suffix = "user/profiles/default/attributes.xml"
+        exe_suffix = "hunt.exe"
         hunt_dir = QFileDialog.getExistingDirectory(self,"Select folder",settings.value('hunt_dir','.'))
-        xml_path = os.path.join(hunt_dir,suffix)
+        xml_path = os.path.join(hunt_dir,xml_suffix)
+        exe_path = os.path.join(hunt_dir,exe_suffix)
         if not os.path.exists(xml_path):
             log('attributes.xml not found.')
             return
         settings.setValue('hunt_dir',hunt_dir)
         settings.setValue('xml_path',xml_path)
+        settings.setValue('exe_path',exe_path)
         self.steamFolderLabel.setText(settings.value("hunt_dir"))
         if not self.parent().logger.running:
             self.parent().StartLogger()

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import sys
 import ctypes
 import platform
+import subprocess
 from resources import *
 
 from PyQt6.QtWidgets import QApplication
@@ -39,5 +40,9 @@ if __name__ == '__main__':
     app.setWindowIcon(QIcon(resource_path('assets/icons/hsl.ico')))
     if settings.value("xml_path", "") == "":
         window.mainframe.settingsWindow.show()
+
+    if (settings.value("run_game_on_startup", "false").lower() == "true"
+    and "HuntGame.exe" not in subprocess.check_output(['tasklist', '/FI', 'IMAGENAME eq HuntGame.exe']).decode()):
+        os.startfile(settings.value("exe_path", ""))
 
     app.exec()


### PR DESCRIPTION
I added a setting to allow users to run hunt together with the stats logger. For me that is useful as I only need a single shortcut in my taskbar and cannot forget to run the logger. Maybe someone else likes it.