### PR TITLE
Partial name searching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ settings.ini
 aws.json
 .VSCodeCounter
 style_processed.qss
+.vscode/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Current File",
+      "type": "python",
+      "request": "launch",
+      "program": "src/main.py",
+      "console": "integratedTerminal",
+      "justMyCode": true
+    }
+  ]
+}

--- a/src/DbHandler.py
+++ b/src/DbHandler.py
@@ -678,9 +678,14 @@ def getKillData(ts):
         "assists": assists
     }
 
+def SameGameCount(pid):
+    res = execute_query("select count(*) from 'hunters_view' where 'hunters_view'.profileid = ?" , pid)
+    res = 0 if len(res) == 0 else res[0][0]
+    res = 1 if res < 1 else res
+    return res
 
-def SameTeamCount(name):
-    res = execute_query("select count(*) from 'hunters_view' join 'teams_view' on 'teams_view'.ownteam = 'true' and 'hunters_view'.team_num = 'teams_view'.team_num and 'hunters_view'.timestamp = 'teams_view'.timestamp where 'hunters_view'.blood_line_name = ?" , name)
+def SameTeamCount(pid):
+    res = execute_query("select count(*) from 'hunters_view' join 'teams_view' on 'teams_view'.ownteam = 'true' and 'hunters_view'.team_num = 'teams_view'.team_num and 'hunters_view'.timestamp = 'teams_view'.timestamp where 'hunters_view'.profileid = ?" , pid)
     res = 0 if len(res) == 0 else res[0][0]
     return res
 

--- a/src/DbHandler.py
+++ b/src/DbHandler.py
@@ -1,6 +1,7 @@
 import sqlite3
 import ctypes
 from resources import *
+from numpy import concatenate
 
 
 def json_to_db(obj):
@@ -387,6 +388,20 @@ def GetHunterByName(name):
         return GetHunterByProfileId(res[0][0])
     return []
 
+def GetHuntersByPartialName(name):
+    res = execute_query("select profileid from 'hunters' where blood_line_name like ? collate nocase", f"%{name}%")
+    ids = []
+    output = []
+
+    for hunterID in res:
+        if hunterID not in ids:
+            ids.append(hunterID)
+    for hunterID in ids:
+        foundHunter = GetHunterByProfileId(hunterID[0])
+        output = concatenate((output, foundHunter), axis = 0)
+    return output
+
+
 def GetNameByProfileId(pid):
     vals = execute_query("select blood_line_name from 'hunters_view' where profileid is ? limit 1" , pid)
     if len(vals) > 0:
@@ -401,7 +416,7 @@ def GetHunterByProfileId(pid):
         for v in vals:
             res.append({cols[i][1] : v[i] for i in range(len(cols))})
     except Exception as e:
-        log('dbhandler.gethunterbyname')
+        log('dbhandler.GetHunterByProfileId')
         log(e)
     return res
 

--- a/src/DbHandler.py
+++ b/src/DbHandler.py
@@ -1,7 +1,6 @@
 import sqlite3
 import ctypes
 from resources import *
-from numpy import concatenate
 
 
 def json_to_db(obj):
@@ -397,8 +396,7 @@ def GetHuntersByPartialName(name):
         if hunterID not in ids:
             ids.append(hunterID)
     for hunterID in ids:
-        foundHunter = GetHunterByProfileId(hunterID[0])
-        output = concatenate((output, foundHunter), axis = 0)
+        output.append(GetHunterByProfileId(hunterID[0]))
     return output
 
 

--- a/src/MainWindow/Hunters/FrequentHunters.py
+++ b/src/MainWindow/Hunters/FrequentHunters.py
@@ -38,13 +38,12 @@ class FrequentHunters(QGroupBox):
             hWidget.setLayout(hWidget.layout)
             hWidget.setObjectName("HunterWidget")
             name = hunter['name']
-            data = GetHunterByName(name)
             freq = hunter['frequency']
             mmr = hunter['mmr']
             killedme = hunter['killedme']
             killedbyme = hunter['killedbyme']
-            sameTeamCount = SameTeamCount(name)
             pid = hunter['profileid']
+            sameTeamCount = SameTeamCount(pid) 
             allnames = getAllUsernames(pid)
             stars = Label("%s<br>%s" % ("<img src='%s'>" %
                            (star_path()) * mmr_to_stars(mmr), mmr))

--- a/src/MainWindow/Hunters/HunterSearch.py
+++ b/src/MainWindow/Hunters/HunterSearch.py
@@ -1,4 +1,4 @@
-from PyQt6.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QGroupBox, QScrollArea, QLineEdit, QPushButton
+from PyQt6.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QGroupBox, QScrollArea, QLineEdit, QPushButton, QLabel
 from PyQt6.QtCore import Qt
 from resources import settings, star_path, mmr_to_stars
 from DbHandler import GetTopNHunters, GetHunterKills, GetHuntersByPartialName, execute_query, getAllUsernames
@@ -29,19 +29,21 @@ class HunterSearch(QGroupBox):
         res = GetHuntersByPartialName(name)
         self.ShowResults(res, name)
 
-    def ShowResults(self, data, name):
+    def ShowResults(self, huntsPerPlayer, name):
         resultsWindow = Modal(parent=self)
-        if len(data) <= 0:
+        if len(huntsPerPlayer) <= 0:
             resultsWindow.addWidget(
                 Label("You've never encountered %s in a Hunt." % name))
         else:
-            for hunter in data:
+            for playerHunts in huntsPerPlayer:
+                firstHunt = playerHunts[0]
+                pid = firstHunt['profileid']
                 resultsWindow.addWidget(
-                    QLabel("You've seen %s in %d hunts." % (hunter[0]['blood_line_name'], len(hunter))))
-                pid = hunter[0]['profileid']
+                    QLabel("You've seen %s in %d hunts." % (firstHunt['blood_line_name'], len(playerHunts))))
+                
                 allnames = getAllUsernames(pid)
                 kills = GetHunterKills(pid)
-                sameTeamCount = self.SameTeamCount(hunter)
+                sameTeamCount = self.SameTeamCount(playerHunts)
 
                 killedby = 0
                 killed = 0

--- a/src/Widgets/Modal.py
+++ b/src/Widgets/Modal.py
@@ -1,14 +1,24 @@
-from PyQt6.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QPushButton, QSizePolicy
+from PyQt6.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QPushButton, QSizePolicy, QScrollArea, QScrollBar
 from PyQt6.QtCore import Qt
 
 class Modal(QMainWindow):
     def __init__(self, parent=None,flags=Qt.WindowType.Popup):
         super().__init__(parent,flags)
         self.setObjectName("popup")
+        self.scrollArea = QScrollArea()
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollArea.setMinimumWidth(450)
+        self.scrollArea.setMinimumHeight(500)
+        self.scrollArea.setMaximumHeight(self.width())
+        self.scrollArea.setMaximumHeight(self.height())
+
         self.body = QWidget()
         self.body.layout = QVBoxLayout()
         self.body.setLayout(self.body.layout)
-        self.setCentralWidget(self.body)
+
+        self.scrollArea.setWidget(self.body)
+
+        self.setCentralWidget(self.scrollArea)
 
         self.closeBtn = QPushButton("OK")
         self.closeBtn.setSizePolicy(QSizePolicy.Policy.Fixed,QSizePolicy.Policy.Fixed)
@@ -24,8 +34,8 @@ class Modal(QMainWindow):
         )
 
     def addWidget(self,widget):
-        self.body.layout.insertWidget(self.body.layout.count()-1,widget,0,Qt.AlignmentFlag.AlignCenter)
-        self.body.layout.setAlignment(widget,Qt.AlignmentFlag.AlignCenter)
+        self.body.layout.insertWidget(self.body.layout.count()-1,widget,Qt.AlignmentFlag.AlignLeft)
+        self.body.layout.setAlignment(widget,Qt.AlignmentFlag.AlignLeft)
         self.adjustSize()
         self.move(
             int(self.parent().window().pos().x() + self.parent().window().width()/2 - self.width()/2),


### PR DESCRIPTION
Interested to hear your thoughts on whether having partial search would be useful for hunter data, specifically in the case that hunters use annoying characters (looking at you `†`) which makes them much harder to search for in the moment. Not a complete implementation and rather ugly since it's using a view not intended for multiple hunters.

![image](https://github.com/majikat768/HuntStatsLogger/assets/5308823/248b9962-a178-440a-b137-daa4512a6bfc)
![image](https://github.com/majikat768/HuntStatsLogger/assets/5308823/4049eaa3-4d41-4156-a558-d30e59617ff3)


Also tightened up the SameTeamCount to use profileid instead of steam_name since players can change their name at-will but I believe the profileid is a bit more "locked in"