### PR TITLE
Tighten up sameTeamCount

### DIFF
--- a/src/MainWindow/Hunters/HunterSearch.py
+++ b/src/MainWindow/Hunters/HunterSearch.py
@@ -68,15 +68,15 @@ class HunterSearch(QGroupBox):
             teamnums[d['game_id']] = d['team_num']
         teams = []
         for id in teamnums:
-            t = execute_query(
-                "select blood_line_name from 'hunters' where game_id is '%s' and team_num is %d" % (id, teamnums[id]))
+            pids = execute_query(
+                "select profileid from 'hunters' where game_id is '%s' and team_num is %d" % (id, teamnums[id]))
             team = []
-            for n in t:
-                team.append(n[0])
+            for pid in pids:
+                team.append(pid[0])
             teams.append(team)
         n = 0
-        me = settings.value("steam_name")
+        myId = int(settings.value("profileid"))
         for team in teams:
-            if me in team:
+            if myId in team:
                 n += 1
         return n


### PR DESCRIPTION
Apologies for the delay, got distracted with other work, just separating concerns from https://github.com/majikat768/HuntStatsLogger/pull/69 before I continue with the partial name search. This should make it so that it'll find more allies games' if they've used multiple names.