### PR TITLE
prompt for steam directory

### DIFF
--- a/src/SettingsWindow.py
+++ b/src/SettingsWindow.py
@@ -110,10 +110,19 @@ class SettingsWindow(QMainWindow):
         self.main.layout.addWidget(self.huntLimitWidget)
 
     def initSteamOptions(self):
-        self.steamFolderLabel = Label(settings.value("hunt_dir","<i>ex: C:/Steam/steamapps/common/Hunt Showdown</i>"))
-        self.steamFolderButton = QPushButton("Select Hunt Installation Directory")
+        self.huntFolderLabel = Label(settings.value("hunt_dir","<i>ex: C:/Steam/steamapps/common/Hunt Showdown</i>"))
+        self.huntFolderButton = QPushButton("Select Hunt Installation Directory")
+        self.huntFolderButton.setSizePolicy(QSizePolicy.Policy.Fixed,QSizePolicy.Policy.Fixed)
+        self.huntFolderButton.clicked.connect(self.SelectHuntFolderDialog)
+        self.main.layout.addWidget(self.huntFolderLabel)
+        self.main.layout.addWidget(self.huntFolderButton)
+        self.main.layout.setAlignment(self.huntFolderButton,Qt.AlignmentFlag.AlignHCenter)
+
+        self.steamFolderLabel = Label(settings.value("steam_dir","<i>ex: C:/Steam</i>"))
+        self.steamFolderButton = QPushButton("Select Steam Installation Directory")
         self.steamFolderButton.setSizePolicy(QSizePolicy.Policy.Fixed,QSizePolicy.Policy.Fixed)
-        self.steamFolderButton.clicked.connect(self.SelectFolderDialog)
+        self.steamFolderButton.setToolTip("Needed to launch the game in case Hunt is not installed in its default location")
+        self.steamFolderButton.clicked.connect(self.SelectSteamFolderDialog)
         self.main.layout.addWidget(self.steamFolderLabel)
         self.main.layout.addWidget(self.steamFolderButton)
         self.main.layout.setAlignment(self.steamFolderButton,Qt.AlignmentFlag.AlignHCenter)
@@ -204,7 +213,7 @@ class SettingsWindow(QMainWindow):
         else:
             self.steamNameInput.setDisabled(False)
     
-    def SelectFolderDialog(self):
+    def SelectHuntFolderDialog(self):
         xml_suffix = "user/profiles/default/attributes.xml"
         hunt_dir = QFileDialog.getExistingDirectory(self,"Select folder",settings.value('hunt_dir','.'))
         xml_path = os.path.join(hunt_dir,xml_suffix)
@@ -213,11 +222,19 @@ class SettingsWindow(QMainWindow):
             return
         settings.setValue('hunt_dir',hunt_dir)
         settings.setValue('xml_path',xml_path)
-        self.steamFolderLabel.setText(settings.value("hunt_dir"))
+        self.huntFolderLabel.setText(settings.value("hunt_dir"))
+        if not self.parent().logger.running:
+            self.parent().StartLogger()
+
+    def SelectSteamFolderDialog(self):
+        steam_dir = QFileDialog.getExistingDirectory(self,"Select folder",settings.value('hunt_dir','.'))
+        settings.setValue('steam_dir',steam_dir)
+        self.steamFolderLabel.setText(settings.value("steam_dir"))
         if not self.parent().logger.running:
             self.parent().StartLogger()
 
     def show(self):
-        self.steamFolderLabel.setText(settings.value("hunt_dir"))
+        self.huntFolderLabel.setText(settings.value("hunt_dir"))
+        self.steamFolderLabel.setText(settings.value("steam_dir"))
         self.steamNameInput.setText(settings.value("steam_name"))
         super().show()

--- a/src/resources.py
+++ b/src/resources.py
@@ -157,8 +157,10 @@ def GoToHuntPage(timestamp,main):
 def launch_hunt():
     if (settings.value("hunt_dir","") != "" and "HuntGame.exe" not in subprocess.check_output(['tasklist', '/FI', 'IMAGENAME eq HuntGame.exe']).decode()):
         log("starting hunt.exe")
-        steam_dir ="/".join(settings.value("hunt_dir").split("/")[:-3])
+        # if no steam_dir is set in the settings, try to guess steam.exe location based on hunt_dir
+        steam_dir = settings.value("steam_dir","/".join(settings.value("hunt_dir").split("/")[:-3]))
         steam_exe = os.path.join(steam_dir,"steam.exe").replace("\\","/")
+        log("using " + steam_exe)
         subprocess.Popen([steam_exe,"steam://rungameid/"+game_id])
 
 with open(resource_path('./assets/json/maps.json'),'r') as f:


### PR DESCRIPTION
resolves #77
It as a starting point that works well but I have a couple of issues with it.

- We should ask for the steam directory first and try to derive the hunt directory from it instead of the other way around as this would be more intuitive to the user. For compatibility reasons I did it this way though.
- The tool tip is light grey on white which is hard to read but I have no idea how the colors work and hope you have an easier time figuring this out. From the docs I only know that `Tool tips use the inactive color group of [QPalette](https://doc.qt.io/qt-6/qpalette.html), because tool tips are not active windows.` In case this is helpful for you.
- I am not really proud of the text of the tool tip but didn't really found a brief explaination that I liked. This would be easier if the prompts were switched like I mentioned in the first point.


I'd like to hear you opinion and would like to implement a solution for the first point in a new commit. I got the following idea while typing these lines:

Maybe in case `hunt_dir` is set but `steam_dir` isn't, we should just assume it like I do in this change if the latter is not set. In case the assumption is correct everything is fine and in case it is not, only running the game would be affected but that wouldn't have worked anyway - so no regression.