### PR TITLE
performance improvement

### DIFF
--- a/src/DbHandler.py
+++ b/src/DbHandler.py
@@ -220,10 +220,16 @@ def GetHunts(IsQuickPlay = 'all'):
     elif IsQuickPlay == 'false':
         condition = "where MissionBagIsQuickPlay = 'false'"
 
-    vals = execute_query("select * from 'games_view' %s order by timestamp desc" % condition)
-    cols = execute_query("pragma table_info('games_view')")
+    vals = execute_query("select\
+                            gv.timestamp, gv.MissionBagIsHunterDead, gv.MissionBagWasDeathlessUsed, gv.MissionBagIsQuickPlay, gv.MissionBagNumTeams,\
+                            sum(hv.downedbyme + hv.killedbyme + hv.downedbyteammate + hv.killedbyteammate)\
+                         from 'games_view' as gv inner join 'hunters_view' as hv on gv.timestamp = hv.timestamp\
+                         %s\
+                         group by gv.timestamp\
+                         order by gv.timestamp desc" % condition)
+    cols = [ "timestamp", "MissionBagIsHunterDead", "MissionBagWasDeathlessUsed", "MissionBagIsQuickPlay", "MissionBagNumTeams", "kills"]
     try:
-        return [ { cols[i][1] : hunt[i] for i in range(len(cols)) } for hunt in vals]
+        return [ dict(zip(cols, hunt)) for hunt in vals]
     except Exception as e:
         log('dbhandler.gethunts')
         log(e)

--- a/src/MainWindow/Hunts/Hunts.py
+++ b/src/MainWindow/Hunts/Hunts.py
@@ -178,7 +178,7 @@ class Hunts(QWidget):
             gameType = "Quick Play" if hunt['MissionBagIsQuickPlay'].lower(
             ) == 'true' else "Bounty Hunt"
             nTeams = hunt['MissionBagNumTeams']
-            nKills = "%d kills" % sum(getKillData(ts)['team_kills'].values())
+            nKills = "%d kills" % hunt['kills']
             ln = "%s - %s - %s %s - %s" % (dt, gameType, nTeams,
                                            "teams" if gameType == "Bounty Hunt" else "hunters", nKills)
             icon = QIcon(deadIcon if dead else livedIcon)


### PR DESCRIPTION
Hi,

I am aproaching 1000 logged hunts (889 to be precise) and slowly but surely I got dissatisfied with the boot up time of the app. It turns out that the way the number of kills for each match in the dropdown box was calculated had a massive impact on the performance. It got calculated by a single query for each match which scales really poorly. With this PR the kills get pulled from the DB with a single query along all the other info that is retrieved anyway.

As I changed the returned columns of `GetHunts()` please have a carefull look if that is fine for all the callers. I only found the location I made the change for and a call in `MyTeams.py`. The latter only cares about the timestamp and should be fine.

I did some poor mans performance measurements by commenting out everything from `mainUpdate()` in `MainFrame.py` except `self.huntsTab.update()` to somewhat isolate the changes I made. By hand, I then just measured the time it takes for the main window to come up. Drumroll... I got it from roughly 15s down to about 2s so the difference is massive.

The second biggest culprit is the teams tab but I haven't looked into it.